### PR TITLE
[FEAT] 공휴일 command 개발 완료

### DIFF
--- a/src/main/java/com/ideality/coreflow/attachment/query/dto/ResponseAttachmentDTO.java
+++ b/src/main/java/com/ideality/coreflow/attachment/query/dto/ResponseAttachmentDTO.java
@@ -1,0 +1,20 @@
+package com.ideality.coreflow.attachment.query.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ResponseAttachmentDTO {
+
+    private Long id;
+    private String url;
+    private String fileType;
+    private String size;
+    private String targetType;
+    private Long targetId;
+}

--- a/src/main/java/com/ideality/coreflow/holiday/command/application/controller/HolidayController.java
+++ b/src/main/java/com/ideality/coreflow/holiday/command/application/controller/HolidayController.java
@@ -1,0 +1,42 @@
+package com.ideality.coreflow.holiday.command.application.controller;
+
+import com.ideality.coreflow.holiday.command.application.service.HolidayService;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/holidays")
+public class HolidayController {
+
+    private final HolidayService holidayService;
+
+    @PostMapping("/update")
+    public ResponseEntity<Map<String,Object>> updateHoliday(@RequestParam int year) {
+        int savedCount = holidayService.updateHolidays(year);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "success");
+        response.put("message", year+"년 휴일 정보 업데이트 완료");
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("holidays", savedCount);
+
+        response.put("data", data);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/test")
+    public ResponseEntity<String> insertDummyHoliday() {
+        holidayService.insertDummyHoliday();
+        return ResponseEntity.ok("더미 공휴일 저장 완료");
+    }
+}
+

--- a/src/main/java/com/ideality/coreflow/holiday/command/application/dto/HolidayApiResponse.java
+++ b/src/main/java/com/ideality/coreflow/holiday/command/application/dto/HolidayApiResponse.java
@@ -1,0 +1,45 @@
+// HolidayApiResponse.java
+package com.ideality.coreflow.holiday.command.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HolidayApiResponse {
+    private Response response;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Getter @Setter
+    public static class Response {
+        private Header header;
+        private Body body;
+    }
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Getter @Setter
+    public static class Header {
+        private String resultCode;
+        private String resultMsg;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Getter @Setter
+    public static class Body {
+        private Items items;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Getter @Setter
+    public static class Items {
+        private HolidayItem[] item;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Getter @Setter
+    public static class HolidayItem {
+        private String dateName;  // 공휴일 이름
+        private String locdate;   // 날짜 (yyyyMMdd)
+    }
+}

--- a/src/main/java/com/ideality/coreflow/holiday/command/application/service/HolidayService.java
+++ b/src/main/java/com/ideality/coreflow/holiday/command/application/service/HolidayService.java
@@ -1,0 +1,114 @@
+// HolidayService.java
+package com.ideality.coreflow.holiday.command.application.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ideality.coreflow.holiday.command.application.dto.HolidayApiResponse;
+import com.ideality.coreflow.holiday.command.domain.aggregate.Holiday;
+import com.ideality.coreflow.holiday.command.domain.aggregate.HolidayType;
+import com.ideality.coreflow.holiday.command.domain.aggregate.RepeatType;
+import com.ideality.coreflow.holiday.command.domain.repository.HolidayRepository;
+import java.net.URI;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@RequiredArgsConstructor
+public class HolidayService {
+
+    private final HolidayRepository holidayRepository;
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+
+    @Value("${HOLIDAY_SECRET_KEY}")
+    private String serviceKey;
+
+    public int updateHolidays(int year) {
+        URI url = UriComponentsBuilder
+                .fromUriString("http://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService/getRestDeInfo")
+                .queryParam("ServiceKey", serviceKey)
+                .queryParam("solYear", year)
+                .queryParam("_type", "json")
+                .queryParam("numOfRows", 100)
+                .build(true)
+                .toUri();
+        ResponseEntity<String> response=restTemplate.getForEntity(url, String.class);
+        try {
+            HolidayApiResponse apiResponse = objectMapper.readValue(response.getBody(), HolidayApiResponse.class);
+            HolidayApiResponse.HolidayItem[] items = apiResponse.getResponse()
+                    .getBody()
+                    .getItems()
+                    .getItem();
+
+            List<Holiday> holidays = new ArrayList<>();
+            Set<LocalDate> holidayDates = new HashSet<>();
+
+            for (HolidayApiResponse.HolidayItem item : items) {
+                LocalDate date = LocalDate.parse(item.getLocdate(), DateTimeFormatter.BASIC_ISO_DATE);
+                Holiday holiday = Holiday.builder()
+                        .name(item.getDateName())
+                        .date(date)
+                        .type(HolidayType.NATIONAL)
+                        .isRepeat(RepeatType.ONCE)
+                        .build();
+
+                holidays.add(holiday);
+                holidayDates.add(date);
+            }
+
+            LocalDate start=LocalDate.of(year,1,1);
+            LocalDate end=LocalDate.of(year,12,31);
+            for(LocalDate date=start;!date.isAfter(end);date=date.plusDays(1)){
+                DayOfWeek day=date.getDayOfWeek();
+                if((day == DayOfWeek.SATURDAY || day == DayOfWeek.SUNDAY)&&!holidayDates.contains(date)){
+                    Holiday weekend=Holiday.builder()
+                            .name(day==DayOfWeek.SATURDAY?"토요일":"일요일")
+                            .date(date)
+                            .type(day==DayOfWeek.SATURDAY?HolidayType.SATURDAY:HolidayType.SUNDAY)
+                            .isRepeat(RepeatType.ONCE)
+                            .build();
+                    holidays.add(weekend);
+                }
+            }
+
+            holidays.sort(Comparator.comparing(Holiday::getDate));
+            List<Holiday> saved = holidayRepository.saveAll(holidays);
+            int savedCount = saved.size();
+            System.out.println("공휴일 " +savedCount+"개 저장 완료");
+            return savedCount;
+
+        } catch (Exception e) {
+            System.out.println("에러 발생");
+            return 0;
+        }
+    }
+
+    public void insertDummyHoliday() {
+        Holiday dummy = Holiday.builder()
+                .name("민수 탄신일")
+                .date(LocalDate.parse("1997-09-18"))
+                .type(HolidayType.NATIONAL)
+                .isRepeat(RepeatType.ONCE)
+                .build();
+        Holiday saved=holidayRepository.save(dummy);
+        if (saved==null) {
+            System.out.println("더미데이터 1개 저장 성공");
+        }
+        else{
+            System.out.println("무언가 잘못됨");
+        }
+    }
+}

--- a/src/main/java/com/ideality/coreflow/holiday/command/domain/aggregate/HolidayType.java
+++ b/src/main/java/com/ideality/coreflow/holiday/command/domain/aggregate/HolidayType.java
@@ -2,5 +2,7 @@ package com.ideality.coreflow.holiday.command.domain.aggregate;
 
 public enum HolidayType {
     COMPANY,
-    NATIONAL
+    NATIONAL,
+    SATURDAY,
+    SUNDAY
 }

--- a/src/main/java/com/ideality/coreflow/holiday/command/domain/repository/HolidayRepository.java
+++ b/src/main/java/com/ideality/coreflow/holiday/command/domain/repository/HolidayRepository.java
@@ -1,0 +1,9 @@
+package com.ideality.coreflow.holiday.command.domain.repository;
+
+import com.ideality.coreflow.holiday.command.domain.aggregate.Holiday;
+import java.time.LocalDate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HolidayRepository extends JpaRepository<Holiday, Long> {
+    boolean existsByDate(LocalDate date);
+}

--- a/src/main/java/com/ideality/coreflow/infra/tenant/config/DataSourceConfig.java
+++ b/src/main/java/com/ideality/coreflow/infra/tenant/config/DataSourceConfig.java
@@ -57,7 +57,8 @@ public class DataSourceConfig {
         factory.setDataSource(dataSource);
         factory.setPackagesToScan("com.ideality.coreflow.common.tenant",
             "com.ideality.coreflow.template.command.domain.aggregate",
-            "com.ideality.coreflow.attachment.command.domain.aggregate"
+            "com.ideality.coreflow.attachment.command.domain.aggregate",
+            "com.ideality.coreflow.holiday.command.domain.aggregate"
         );
         factory.setJpaVendorAdapter(vendorAdapter);
         factory.setJpaPropertyMap(jpaProperties.getProperties());

--- a/src/main/resources/sql/DDL.sql
+++ b/src/main/resources/sql/DDL.sql
@@ -66,7 +66,7 @@ CREATE TABLE holiday (
     name VARCHAR(255) NOT NULL,
     type VARCHAR(255) NOT NULL,
     is_repeat VARCHAR(255) NOT NULL DEFAULT 'ONCE',
-    CHECK (type IN ('COMPANY', 'NATIONAL')),
+    CHECK (type IN ('COMPANY', 'NATIONAL', 'SATURDAY', 'SUNDAY')),
     CHECK (is_repeat IN ('YEARLY', 'ONCE'))
 );
 


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 특정 연도에 대한 휴일 업데이트 요청이 들어오면 해당 연도의 휴일 정보가 DB에 저장되는 기능 구현

## 📌 변경 사항 (Changes)
- [ ] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 🌿 작업한 브랜치 (Working Branch)
> feature/holiday/api

- 현재 PR이 어떤 브랜치에서 작업되었는지 명시해주세요.
- feature/holiday/api

## 📂 관련 이슈 (Issue)
- close #39 

## 💡 추가 설명 (Additional Info)
> 노션에 HOLIDAY_SECRET_KEY 추가해두었습니다
> /api/holidays/update?year=2025(원하는 연도) 로 요청 보내면 됩니다
> DDL 수정된 부분 있습니다. ****반드시**** pull 받으신 후 DDL 다시 실행 하신 다음에 실행하셔야 합니다
    > 수정 내용 (HolidayType으로 SATURDAY와 SUNDAY 추가)
> 아직 예외처리는 하지 않았습니다
> 중복 처리가 반만 되어있습니다
    > 하나의 요청을 처리할 때 주말 데이터와 공휴일 데이터는 중복되지 않습니다 (주말과 공휴일이 겹칠 경우 공휴일로 저장)
    > 하나의 요청을 처리할 때 해당 데이터가 DB에 이미 있는지는 확인하지 않습니다

## 📎 기타 참고 사항
- Response-data-holidays로 휴일이 몇개 추가되었는지 조회 가능합니다
- api/holiday/test 로 간단 테스트 가능합니다

## 📸 스크린샷 (선택)
<img width="674" alt="image" src="https://github.com/user-attachments/assets/fe9e71ac-253b-4ebf-8ef8-b598c4e22ca6" />
