### PR TITLE
[REFACTOR] 태스크 목록 조회시, 세부 일정 조회 안되게, 완료 수정 삭제 PATCH으로 변경, 딜리트 된것 조회 안되게 설정

### DIFF
--- a/src/main/java/com/ideality/coreflow/common/exception/ErrorCode.java
+++ b/src/main/java/com/ideality/coreflow/common/exception/ErrorCode.java
@@ -55,7 +55,8 @@ public enum ErrorCode {
     INVALID_STATUS_DELETED("INVALID_STATUS_DELETED", "이미 삭제된 작업입니다.", HttpStatus.CONFLICT),
 
     INVALID_SOURCE_LIST("INVALID_SOURCE_LIST", "source는 null이거나 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST),
-    INVALID_TARGET_LIST("INVALID_TARGET_LIST", "target은 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST)
+    INVALID_TARGET_LIST("INVALID_TARGET_LIST", "target은 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST),
+    TASK_PROGRESS_NOT_COMPLETED("TASK_PROGRESS_NOT_COMPLETED","진행률이 100%여야 작업을 완료할 수 있습니다.", HttpStatus.BAD_REQUEST)
     ;
 
     private final String code;

--- a/src/main/java/com/ideality/coreflow/project/command/application/controller/TaskController.java
+++ b/src/main/java/com/ideality/coreflow/project/command/application/controller/TaskController.java
@@ -25,7 +25,7 @@ public class TaskController {
         );
     }
 
-    @PutMapping("/progress/{taskId}")
+    @PatchMapping("/progress/{taskId}")
     public ResponseEntity<APIResponse<Map<String, Long>>> updateTaskByProgress(
             @PathVariable Long taskId) {
         Long updatedTaskId = projectFacadeService.updateStatusProgress(taskId);
@@ -35,7 +35,7 @@ public class TaskController {
         );
     }
 
-    @PutMapping("/complete/{taskId}")
+    @PatchMapping("/complete/{taskId}")
     public ResponseEntity<APIResponse<Map<String, Long>>> updateTaskByComplete(
             @PathVariable Long taskId) {
         Long updatedTaskId = projectFacadeService.updateStatusComplete(taskId);
@@ -45,7 +45,7 @@ public class TaskController {
         );
     }
 
-    @PutMapping("/delete/{taskId}")
+    @PatchMapping("/delete/{taskId}")
     public ResponseEntity<APIResponse<Map<String, Long>>> softDeleteTask(
             @PathVariable Long taskId
     ) {

--- a/src/main/java/com/ideality/coreflow/project/command/application/service/impl/TaskServiceImpl.java
+++ b/src/main/java/com/ideality/coreflow/project/command/application/service/impl/TaskServiceImpl.java
@@ -13,8 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.ideality.coreflow.common.exception.ErrorCode.INVALID_SOURCE_LIST;
-import static com.ideality.coreflow.common.exception.ErrorCode.TASK_NOT_FOUND;
+import static com.ideality.coreflow.common.exception.ErrorCode.*;
 
 @Service
 @Slf4j
@@ -58,6 +57,10 @@ public class TaskServiceImpl implements TaskService {
     public Long updateStatusComplete(Long taskId) {
         Work updatedTask = taskRepository.findById(taskId)
                 .orElseThrow(() -> new BaseException(TASK_NOT_FOUND));
+
+        if (updatedTask.getProgressRate() != 100) {
+            throw new BaseException(TASK_PROGRESS_NOT_COMPLETED);
+        }
 
         updatedTask.endTask();
         return updatedTask.getId();

--- a/src/main/java/com/ideality/coreflow/project/command/domain/aggregate/Work.java
+++ b/src/main/java/com/ideality/coreflow/project/command/domain/aggregate/Work.java
@@ -78,6 +78,7 @@ public class Work {
 		}
 
 		this.status = Status.PROGRESS;
+		this.startReal = LocalDate.now();
 	}
 
 	public void endTask() {

--- a/src/main/resources/mapper/TaskMapper.xml
+++ b/src/main/resources/mapper/TaskMapper.xml
@@ -38,6 +38,7 @@
              , delay_days
           FROM work
          WHERE id = #{taskId}
+           AND status != 'DELETED'
     </select>
 
     <select id="selectTasks" parameterType="map" resultMap="TasksMap">
@@ -51,5 +52,7 @@
           FROM work a
           JOIN project b ON a.project_id = b.id
          WHERE b.id = #{projectId}
+           AND a.parent_task_id IS NULL
+           AND a.status != 'DELETED'
     </select>
 </mapper>


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.
1. 태스크 목록 조회시 세부 일정 조회 안되게 쿼리 변경
2. 업데이트 관련 전부 PUT -> PATCH로 변경
3. 기존의 태스크 조회 관련된 것 전부 DELETED 되지 않은 것들 전부 조회 안되게 변경
4. 태스크 완료 될 때 100퍼 아니면 안되게 예외까지 추가 완료

## 📌 변경 사항 (Changes)
- [ ] 주요 기능 추가 / 변경
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 🌿 작업한 브랜치 (Working Branch)
> 예: `feature/게시글-작성`

- 현재 PR이 어떤 브랜치에서 작업되었는지 명시해주세요.
- close #88 
- close #89 

## 📂 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요. (`#이슈번호`)

## 💡 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)

## 📎 기타 참고 사항
- 코드 리뷰 중점적으로 봐줬으면 하는 부분
- 구현 중 고민된 점 등

## 📸 스크린샷 (선택)
UI 관련 변경사항이 있다면 스크린샷을 첨부해주세요.