### PR TITLE
[FEAT] 참여중인 프로젝트 목록 조회 구현 완료

### DIFF
--- a/src/main/java/com/ideality/coreflow/project/query/controller/ProjectQueryController.java
+++ b/src/main/java/com/ideality/coreflow/project/query/controller/ProjectQueryController.java
@@ -1,0 +1,26 @@
+package com.ideality.coreflow.project.query.controller;
+
+import com.ideality.coreflow.common.response.APIResponse;
+import com.ideality.coreflow.project.query.dto.ProjectSummaryDTO;
+import com.ideality.coreflow.project.query.service.ProjectQueryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/projects")
+@RequiredArgsConstructor
+public class ProjectQueryController {
+
+    private final ProjectQueryService projectQueryService;
+
+    @GetMapping("/list") // 임시로 userId를 param으로 받아옴. 추후 반드시 수정
+    public APIResponse<List<ProjectSummaryDTO>> getProjects(@RequestParam Long userId) {
+        List<ProjectSummaryDTO> projects = projectQueryService.selectProjectSummaries(userId);
+        return APIResponse.success(projects, "참여중인 프로젝트 목록 조회 완료");
+
+    }
+}

--- a/src/main/java/com/ideality/coreflow/project/query/controller/ProjectQueryController.java
+++ b/src/main/java/com/ideality/coreflow/project/query/controller/ProjectQueryController.java
@@ -20,7 +20,7 @@ public class ProjectQueryController {
     @GetMapping("/list") // 임시로 userId를 param으로 받아옴. 추후 반드시 수정
     public APIResponse<List<ProjectSummaryDTO>> getProjects(@RequestParam Long userId) {
         List<ProjectSummaryDTO> projects = projectQueryService.selectProjectSummaries(userId);
-        return APIResponse.success(projects, "참여중인 프로젝트 목록 조회 완료");
-
+        int count=projects.size();
+        return APIResponse.success(projects, "참여중인 프로젝트 목록 조회 완료 ("+count+"개)");
     }
 }

--- a/src/main/java/com/ideality/coreflow/project/query/controller/ProjectQueryController.java
+++ b/src/main/java/com/ideality/coreflow/project/query/controller/ProjectQueryController.java
@@ -3,6 +3,7 @@ package com.ideality.coreflow.project.query.controller;
 import com.ideality.coreflow.common.response.APIResponse;
 import com.ideality.coreflow.project.query.dto.ProjectSummaryDTO;
 import com.ideality.coreflow.project.query.service.ProjectQueryService;
+import com.ideality.coreflow.project.query.service.facade.ProjectQueryFacadeService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,11 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ProjectQueryController {
 
-    private final ProjectQueryService projectQueryService;
+    private final ProjectQueryFacadeService projectQueryFacadeService;
 
     @GetMapping("/list") // 임시로 userId를 param으로 받아옴. 추후 반드시 수정
     public APIResponse<List<ProjectSummaryDTO>> getProjects(@RequestParam Long userId) {
-        List<ProjectSummaryDTO> projects = projectQueryService.selectProjectSummaries(userId);
+        List<ProjectSummaryDTO> projects = projectQueryFacadeService.selectProjectSummaries(userId);
         int count=projects.size();
         return APIResponse.success(projects, "참여중인 프로젝트 목록 조회 완료 ("+count+"개)");
     }

--- a/src/main/java/com/ideality/coreflow/project/query/dto/DirectorSummaryDTO.java
+++ b/src/main/java/com/ideality/coreflow/project/query/dto/DirectorSummaryDTO.java
@@ -1,0 +1,11 @@
+package com.ideality.coreflow.project.query.dto;
+
+import lombok.Getter;
+
+@Getter
+public class DirectorSummaryDTO {
+    private String name;
+    private String deptName;
+    private String jobRoleName;
+    private String profileImage;
+}

--- a/src/main/java/com/ideality/coreflow/project/query/dto/ProjectSummaryDTO.java
+++ b/src/main/java/com/ideality/coreflow/project/query/dto/ProjectSummaryDTO.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 
 @Getter
 public class ProjectSummaryDTO {
+    private Long id;
     private String name;
     private Status status;
     private String startDate;

--- a/src/main/java/com/ideality/coreflow/project/query/dto/ProjectSummaryDTO.java
+++ b/src/main/java/com/ideality/coreflow/project/query/dto/ProjectSummaryDTO.java
@@ -1,0 +1,16 @@
+package com.ideality.coreflow.project.query.dto;
+
+
+import com.ideality.coreflow.approval.domain.aggregate.Status;
+
+public class ProjectSummaryDTO {
+    private String name;
+    private Status status;
+    private String startDate;
+    private String endDate;
+    private DirectorSummaryDTO director;
+    private Double progressRate;
+    private Double passedRate;
+    private Integer delayDays;
+
+}

--- a/src/main/java/com/ideality/coreflow/project/query/dto/ProjectSummaryDTO.java
+++ b/src/main/java/com/ideality/coreflow/project/query/dto/ProjectSummaryDTO.java
@@ -2,7 +2,9 @@ package com.ideality.coreflow.project.query.dto;
 
 
 import com.ideality.coreflow.approval.domain.aggregate.Status;
+import lombok.Getter;
 
+@Getter
 public class ProjectSummaryDTO {
     private String name;
     private Status status;

--- a/src/main/java/com/ideality/coreflow/project/query/mapper/ProjectMapper.java
+++ b/src/main/java/com/ideality/coreflow/project/query/mapper/ProjectMapper.java
@@ -1,0 +1,10 @@
+package com.ideality.coreflow.project.query.mapper;
+
+import com.ideality.coreflow.project.query.dto.ProjectSummaryDTO;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface ProjectMapper {
+    List<ProjectSummaryDTO> selectParticipatingProjects(Long userId);
+}

--- a/src/main/java/com/ideality/coreflow/project/query/service/ProjectQueryService.java
+++ b/src/main/java/com/ideality/coreflow/project/query/service/ProjectQueryService.java
@@ -1,0 +1,8 @@
+package com.ideality.coreflow.project.query.service;
+
+import com.ideality.coreflow.project.query.dto.ProjectSummaryDTO;
+import java.util.List;
+
+public interface ProjectQueryService {
+    List<ProjectSummaryDTO> selectProjectSummaries(Long userId);
+}

--- a/src/main/java/com/ideality/coreflow/project/query/service/facade/ProjectQueryFacadeService.java
+++ b/src/main/java/com/ideality/coreflow/project/query/service/facade/ProjectQueryFacadeService.java
@@ -1,9 +1,11 @@
 package com.ideality.coreflow.project.query.service.facade;
 
 import com.ideality.coreflow.project.query.dto.DeptWorkDTO;
+import com.ideality.coreflow.project.query.dto.ProjectSummaryDTO;
 import com.ideality.coreflow.project.query.dto.ResponseTaskDTO;
 import com.ideality.coreflow.project.query.dto.ResponseTaskInfoDTO;
 import com.ideality.coreflow.project.query.service.DeptQueryService;
+import com.ideality.coreflow.project.query.service.ProjectQueryService;
 import com.ideality.coreflow.project.query.service.RelationQueryService;
 import com.ideality.coreflow.project.query.service.TaskQueryService;
 import com.ideality.coreflow.project.query.service.WorkDeptQueryService;
@@ -28,6 +30,11 @@ public class ProjectQueryFacadeService {
     private final RelationQueryService relationQueryService;
     private final WorkService workService;
     private final WorkDeptQueryService workDeptQueryService;
+    private final ProjectQueryService projectQueryService;
+
+    public List<ProjectSummaryDTO> selectProjectSummaries(Long userId) {
+        return projectQueryService.selectProjectSummaries(userId);
+    }
 
     public ResponseTaskInfoDTO selectTaskInfo(Long taskId) {
         ResponseTaskInfoDTO selectTask =

--- a/src/main/java/com/ideality/coreflow/project/query/service/impl/ProjectQueryServiceImpl.java
+++ b/src/main/java/com/ideality/coreflow/project/query/service/impl/ProjectQueryServiceImpl.java
@@ -1,0 +1,21 @@
+package com.ideality.coreflow.project.query.service.impl;
+
+import com.ideality.coreflow.project.command.domain.repository.ProjectRepository;
+import com.ideality.coreflow.project.query.dto.ProjectSummaryDTO;
+import com.ideality.coreflow.project.query.mapper.ProjectMapper;
+import com.ideality.coreflow.project.query.service.ProjectQueryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ProjectQueryServiceImpl implements ProjectQueryService {
+
+    private final ProjectMapper projectMapper;
+
+    @Override
+    public List<ProjectSummaryDTO> selectProjectSummaries(Long userId) {
+        return projectMapper.selectParticipatingProjects(userId);
+    }
+}

--- a/src/main/resources/mapper/ProjectMapper.xml
+++ b/src/main/resources/mapper/ProjectMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper>
+<mapper namespace="com.ideality.coreflow.project.query.mapper.ProjectMapper">
     <resultMap id="ProjectSummaryMap" type="com.ideality.coreflow.project.query.dto.ProjectSummaryDTO">
         <result property="name" column="project_name"/>
         <result property="status" column="status"/>
@@ -31,7 +31,7 @@
                     WHEN p.status = 'PENDING' THEN p.end_expect
                     WHEN p.status = 'PROGRESS' THEN p.end_expect
                     WHEN p.status = 'COMPLETED' THEN p.end_base
-               END AS end_date,
+               END AS end_date
              , director.name AS director_name
              , director.dept_name AS dept_name
              , director.job_role_name AS job_role_name

--- a/src/main/resources/mapper/ProjectMapper.xml
+++ b/src/main/resources/mapper/ProjectMapper.xml
@@ -4,6 +4,7 @@
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.ideality.coreflow.project.query.mapper.ProjectMapper">
     <resultMap id="ProjectSummaryMap" type="com.ideality.coreflow.project.query.dto.ProjectSummaryDTO">
+        <result property="id" column="project_id"/>
         <result property="name" column="project_name"/>
         <result property="status" column="status"/>
         <result property="startDate" column="start_date"/>
@@ -20,7 +21,8 @@
     </resultMap>
     <select id="selectParticipatingProjects" resultMap="ProjectSummaryMap">
         SELECT
-               p.name AS project_name
+               p.id AS project_id
+             , p.name AS project_name
              , p.status
              , CASE
                     WHEN p.status = 'PENDING' THEN p.start_expect

--- a/src/main/resources/mapper/ProjectMapper.xml
+++ b/src/main/resources/mapper/ProjectMapper.xml
@@ -47,6 +47,6 @@
                              AND pt.target_type   = 'PROJECT'
                              AND pt.role_id       = 1
           JOIN user director  ON director.id      = pt.user_id
-         WHERE p.status IN ('PENDING', 'PROGRESS', 'COMPLETED')
+<!--         WHERE p.status IN ('PENDING', 'PROGRESS', 'COMPLETED')-->
     </select>
 </mapper>

--- a/src/main/resources/mapper/ProjectMapper.xml
+++ b/src/main/resources/mapper/ProjectMapper.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper>
+    <resultMap id="ProjectSummaryMap" type="com.ideality.coreflow.project.query.dto.ProjectSummaryDTO">
+        <result property="name" column="project_name"/>
+        <result property="status" column="status"/>
+        <result property="startDate" column="start_date"/>
+        <result property="endDate" column="end_date"/>
+        <result property="progressRate" column="progress_rate"/>
+        <result property="passedRate" column="passed_rate"/>
+        <result property="delayDays" column="delay_days"/>
+        <association property="director" javaType="com.ideality.coreflow.project.query.dto.DirectorSummaryDTO">
+            <result property="name" column="director_name"/>
+            <result property="deptName" column="dept_name"/>
+            <result property="jobRoleName" column="job_role_name"/>
+            <result property="profileImage" column="profile_image"/>
+        </association>
+    </resultMap>
+    <select id="selectParticipatingProjects" resultMap="ProjectSummaryMap">
+        SELECT
+               p.name AS project_name
+             , p.status
+             , CASE
+                    WHEN p.status = 'PENDING' THEN p.start_expect
+                    WHEN p.status = 'PROGRESS' THEN p.start_base
+                    WHEN p.status = 'COMPLETED' THEN p.start_base
+               END AS start_date
+             , CASE
+                    WHEN p.status = 'PENDING' THEN p.end_expect
+                    WHEN p.status = 'PROGRESS' THEN p.end_expect
+                    WHEN p.status = 'COMPLETED' THEN p.end_base
+               END AS end_date,
+             , director.name AS director_name
+             , director.dept_name AS dept_name
+             , director.job_role_name AS job_role_name
+             , director.profile_image AS profile_image
+             , p.progress_rate
+             , p.passed_rate
+             , p.delay_days
+          FROM project p
+          JOIN participant me ON me.target_id     = p.id
+                             AND me.target_type   = 'PROJECT'
+                             AND me.user_id       = #{userId}
+          JOIN participant pt ON pt.target_id     = p.id
+                             AND pt.target_type   = 'PROJECT'
+                             AND pt.role_id       = 1
+          JOIN user director  ON director.id      = pt.user_id
+         WHERE p.status IN ('PENDING', 'PROGRESS', 'COMPLETED')
+    </select>
+</mapper>


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 회원이 참여중인 프로젝트 목록을 조회하는 기능 구현 완료

## 📌 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 🌿 작업한 브랜치 (Working Branch)
> feature/project/query/list

- 현재 PR이 어떤 브랜치에서 작업되었는지 명시해주세요.
- feature/project/query/list

## 📂 관련 이슈 (Issue)
- close #102 

## 💡 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)
- 응답 정보를 담는 ProjectSummaryDTO 클래스를 작성하였습니다
- 직관성을 위해 ProjectSummaryDTO 클래스 내부에 DirectorSummaryDTO 클래스를 사용하였습니다
    - 디렉터 이름, 부서 이름, 직책명, 프로필 이미지
- SpringSecurity를 부착하기 전이므로, 조회하는 유저의 user_id를 RequestParam으로 전달받습니다
    - 추후 반드시 수정 요망

## 📎 기타 참고 사항
- https://www.notion.so/ohgiraffers/API-20a649136c1180f0a076cede7fe8b052?source=copy_link

## 📸 스크린샷 (선택)
![✅  프로젝트 목록 페이지](https://github.com/user-attachments/assets/77a03a65-5225-4daf-918a-f57bdc5be344)
