### PR TITLE
[Refactor] 결재 요청 시 첨부파일 리스트도 함께 보내도록 수정

### DIFF
--- a/src/main/java/com/ideality/coreflow/approval/command/application/controller/ApprovalController.java
+++ b/src/main/java/com/ideality/coreflow/approval/command/application/controller/ApprovalController.java
@@ -38,22 +38,11 @@ public class ApprovalController {
     }
 
     // 결재 요청
-    @PostMapping("/request")
-    public ResponseEntity<APIResponse<?>> requestApproval(@RequestBody RequestApproval request) {
+    @PostMapping(value="/request", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<APIResponse<?>> requestApproval(@ModelAttribute RequestApproval request) {
         // request: 결재 정보
         long requesterId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
 
         return ResponseEntity.ok(APIResponse.success(approvalFacadeService.requestApproval(request, requesterId), "결재 요청 완료"));
-    }
-
-    // 첨부파일 업로드
-    @PostMapping(value = "/request/{approvalId}/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<APIResponse<?>> approvalAttachmentUpload(@PathVariable long approvalId, @RequestParam("file") MultipartFile file ) {
-
-        long uploaderId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
-
-        approvalFacadeService.uploadApprovalAttachment(approvalId, file, uploaderId);
-
-        return ResponseEntity.ok(APIResponse.success(null, "첨부파일 등록 완료"));
     }
 }

--- a/src/main/java/com/ideality/coreflow/approval/command/application/dto/RequestApproval.java
+++ b/src/main/java/com/ideality/coreflow/approval/command/application/dto/RequestApproval.java
@@ -2,6 +2,7 @@ package com.ideality.coreflow.approval.command.application.dto;
 
 import com.ideality.coreflow.approval.command.domain.aggregate.ApprovalType;
 import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -23,4 +24,6 @@ public class RequestApproval {
     Integer delayDays;
     Long delayReasonId;
     String actionDetail;
+
+    List<MultipartFile> attachmentFile;
 }

--- a/src/main/java/com/ideality/coreflow/approval/command/application/service/ApprovalFacadeService.java
+++ b/src/main/java/com/ideality/coreflow/approval/command/application/service/ApprovalFacadeService.java
@@ -116,26 +116,26 @@ public class ApprovalFacadeService {
             log.info("지연 정보 등록 완료");
         }
 
-        return approvalId;
-    }
-
-    @Transactional
-    public void uploadApprovalAttachment(long approvalId, MultipartFile file, long uploaderId) {
+        // 첨부파일 업로드
         String folder = "approval-docs";
 
-        UploadFileResult fileResult = s3Service.uploadFile(file, folder);
+        for (MultipartFile file : request.getAttachmentFile()) {
+            UploadFileResult fileResult = s3Service.uploadFile(file, folder);
 
-        RegistAttachmentDTO approvalAttachment = RegistAttachmentDTO.builder()
-                .originName(fileResult.getOriginalName())
-                .storedName(fileResult.getStoredName())
-                .url(fileResult.getUrl())
-                .fileType(file.getContentType())
-                .size(fileResult.getSize())
-                .targetId(approvalId)
-                .uploaderId(uploaderId)
-                .targetType(FileTargetType.APPROVAL)
-                .build();
+            RegistAttachmentDTO approvalAttachment = RegistAttachmentDTO.builder()
+                    .originName(fileResult.getOriginalName())
+                    .storedName(fileResult.getStoredName())
+                    .url(fileResult.getUrl())
+                    .fileType(fileResult.getFileType())
+                    .size(fileResult.getSize())
+                    .targetId(approvalId)
+                    .uploaderId(requesterId)
+                    .targetType(FileTargetType.APPROVAL)
+                    .build();
 
-        attachmentCommandService.registAttachment(approvalAttachment);
+            attachmentCommandService.registAttachment(approvalAttachment);
+        }
+
+        return approvalId;
     }
 }


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 결재 정보 등록 + 첨부파일 한 요청으로 통합
결재 등록하는 요청을 수정하여 첨부파일 리스트도 함께 보내어 결재 등록 요청 api 내에서 트랜잭션으로 묶음

## 📌 변경 사항 (Changes)
- [ ] 주요 기능 추가 / 변경
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 🌿 작업한 브랜치 (Working Branch)
> refactor/sw/registApproval

## 📂 관련 이슈 (Issue)
- close #129 

## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/e0b05f9d-58fc-40a8-8566-b8aed5db4cd6)