### PR TITLE
[FEAT] projectId로 결재 목록 조회하기 기능 구현

### DIFF
--- a/src/main/java/com/ideality/coreflow/approval/query/dto/ProjectApprovalDTO.java
+++ b/src/main/java/com/ideality/coreflow/approval/query/dto/ProjectApprovalDTO.java
@@ -1,0 +1,31 @@
+package com.ideality.coreflow.approval.query.dto;
+
+import com.ideality.coreflow.approval.command.domain.aggregate.ApprovalType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ProjectApprovalDTO {
+    long id;                    // 결재 id
+    String taskName;            // 태스크명
+    LocalDateTime createdDate;  // 생성일
+    String approverName;        // 결재자 명
+    String approverJobRank;     // 결재자 직위
+    String approvalJobRole;     // 결재자 직책
+
+    ApprovalType approvalType;  // 결재 타입 (산출물/지연 사유서)
+
+    String delayReason;         // 지연 사유
+    Integer delayDays;          // 지연 일
+
+    String url;                 // 파일 링크
+
+    // 작성 날짜만 반환 (시간x)
+    public LocalDate getCreatedDate() {
+        return createdDate.toLocalDate();
+    }
+}

--- a/src/main/java/com/ideality/coreflow/approval/query/mapper/ApprovalMapper.java
+++ b/src/main/java/com/ideality/coreflow/approval/query/mapper/ApprovalMapper.java
@@ -1,7 +1,9 @@
 package com.ideality.coreflow.approval.query.mapper;
 
+import com.ideality.coreflow.approval.command.domain.aggregate.ApprovalType;
 import com.ideality.coreflow.approval.query.dto.ApprovalDetailsDTO;
 import com.ideality.coreflow.approval.query.dto.ApprovalParticipantDTO;
+import com.ideality.coreflow.approval.query.dto.ProjectApprovalDTO;
 import com.ideality.coreflow.approval.query.dto.ResponsePreviewApproval;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -20,4 +22,6 @@ public interface ApprovalMapper {
     List<ApprovalParticipantDTO> selectApprovalParticipantById(long approvalId);
 
     ApprovalDetailsDTO selectApprovalDetailsById(long approvalId);
+
+    List<ProjectApprovalDTO> selectProjectApprovalByProjectId(long projectId, ApprovalType approvalType);
 }

--- a/src/main/java/com/ideality/coreflow/approval/query/service/ApprovalQueryService.java
+++ b/src/main/java/com/ideality/coreflow/approval/query/service/ApprovalQueryService.java
@@ -1,7 +1,9 @@
 package com.ideality.coreflow.approval.query.service;
 
+import com.ideality.coreflow.approval.command.domain.aggregate.ApprovalType;
 import com.ideality.coreflow.approval.query.dto.ApprovalDetailsDTO;
 import com.ideality.coreflow.approval.query.dto.ApprovalParticipantDTO;
+import com.ideality.coreflow.approval.query.dto.ProjectApprovalDTO;
 import com.ideality.coreflow.approval.query.dto.ResponsePreviewApproval;
 
 import java.util.List;
@@ -18,4 +20,6 @@ public interface ApprovalQueryService {
     List<ApprovalParticipantDTO> searchApprovalParticipantById(long approvalId);
 
     ApprovalDetailsDTO searchApprovalDetailsById(long approvalId);
+
+    List<ProjectApprovalDTO> selectProjectApprovalByProjectId(long projectId, ApprovalType approvalType);
 }

--- a/src/main/java/com/ideality/coreflow/approval/query/service/impl/ApprovalQueryServiceImpl.java
+++ b/src/main/java/com/ideality/coreflow/approval/query/service/impl/ApprovalQueryServiceImpl.java
@@ -1,7 +1,9 @@
 package com.ideality.coreflow.approval.query.service.impl;
 
+import com.ideality.coreflow.approval.command.domain.aggregate.ApprovalType;
 import com.ideality.coreflow.approval.query.dto.ApprovalDetailsDTO;
 import com.ideality.coreflow.approval.query.dto.ApprovalParticipantDTO;
+import com.ideality.coreflow.approval.query.dto.ProjectApprovalDTO;
 import com.ideality.coreflow.approval.query.dto.ResponsePreviewApproval;
 import com.ideality.coreflow.approval.query.mapper.ApprovalMapper;
 import com.ideality.coreflow.approval.query.service.ApprovalQueryService;
@@ -47,5 +49,10 @@ public class ApprovalQueryServiceImpl implements ApprovalQueryService {
     @Override
     public ApprovalDetailsDTO searchApprovalDetailsById(long approvalId) {
         return approvalMapper.selectApprovalDetailsById(approvalId);
+    }
+
+    @Override
+    public List<ProjectApprovalDTO> selectProjectApprovalByProjectId(long projectId, ApprovalType approvalType) {
+        return approvalMapper.selectProjectApprovalByProjectId(projectId, approvalType);
     }
 }

--- a/src/main/resources/mapper/ApprovalMapper.xml
+++ b/src/main/resources/mapper/ApprovalMapper.xml
@@ -4,6 +4,19 @@
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.ideality.coreflow.approval.query.mapper.ApprovalMapper">
 
+    <resultMap id="ProjectApprovalResultMap" type="com.ideality.coreflow.approval.query.dto.ProjectApprovalDTO">
+        <id property="id" column="ID" />
+        <result property="taskName" column="TASK_NAME" />
+        <result property="createdDate" column="CREATED_AT" />
+        <result property="approverName" column="APPROVER_NAME" />
+        <result property="approverJobRank" column="APPROVER_JOB_RANK" />
+        <result property="approvalJobRole" column="APPROVER_JOB_ROLE" />
+        <result property="approvalType" column="APPROVAL_TYPE" />
+        <result property="delayReason" column="DELAY_REASON" />
+        <result property="delayDays" column="DELAY_DAYS" />
+        <result property="url" column="URL" />
+    </resultMap>
+
     <resultMap id="ApprovalPreviewResultMap" type="com.ideality.coreflow.approval.query.dto.ResponsePreviewApproval">
         <id property="id" column="ID" />
         <result property="requesterName" column="REQUESTER_NAME" />
@@ -35,6 +48,34 @@
         <result property="actionDetail" column="ACTION_DETAIL" />
         <result property="delayReason" column="DELAY_REASON" />
     </resultMap>
+
+    <!--  프로젝트 id와 타입(산출물 / 지연 사유서)으로 승인된 결재 조회  -->
+    <select id="selectProjectApprovalByProjectId" resultMap="ProjectApprovalResultMap">
+        SELECT
+               a.id AS ID
+             , w.name AS TASK_NAME
+             , a.created_at AS CREATED_AT
+             , u.name AS APPROVER_NAME
+             , u.job_rank_name AS APPROVER_JOB_RANK
+             , u.job_role_name AS APPROVER_JOB_ROLE
+             , a.type AS APPROVAL_TYPE
+             , dr.reason AS DELAY_REASON
+             , da.delay_days AS DELAY_DAYS
+             , at.url AS URL
+          FROM approval a
+          LEFT JOIN approval_participant ap ON ap.approval_id = a.id
+          LEFT JOIN user u ON ap.user_id = u.id
+          LEFT JOIN work w ON a.work_id = w.id
+          LEFT JOIN project p ON w.project_id = p.id
+          LEFT JOIN delay_approval da ON a.id = da.approval_id
+          LEFT JOIN delay_reason dr ON da.delay_reason_id = dr.id
+          LEFT JOIN attachment at ON a.id = at.target_id AND at.target_type = 'APPROVAL'
+         WHERE a.type = #{approvalType}
+           AND a.status = 'APPROVED'
+           AND ap.role = 'APPROVER'
+           AND p.id = #{projectId}
+
+    </select>
 
     <!-- 결재 id로 결재 상세 내역 조회 -->
     <select id="selectApprovalDetailsById" parameterType="long" resultMap="ApprovalDetailsResultMap">


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> pdf 작성에 사용할 프로젝트 관련 결재 조회 기능 구현
프로젝트id와 결재 타입(DELIVERABLE / DELAY) 로 pdf에 사용할 프로젝트 관련 결재 조회

## 📌 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 🌿 작업한 브랜치 (Working Branch)
> feature/sw/searchApproval

## 📂 관련 이슈 (Issue)
- close #131 

## 💡 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)

## 📎 기타 참고 사항
- 코드 리뷰 중점적으로 봐줬으면 하는 부분
- 구현 중 고민된 점 등

## 📸 스크린샷 (선택)
UI 관련 변경사항이 있다면 스크린샷을 첨부해주세요.