### PR TITLE
[FEAT] 태스크 진척률 업데이트 시 프로젝트 진척률 자동 업데이트

### DIFF
--- a/src/main/java/com/ideality/coreflow/project/command/application/service/ProjectService.java
+++ b/src/main/java/com/ideality/coreflow/project/command/application/service/ProjectService.java
@@ -20,5 +20,5 @@ public interface ProjectService {
 
     Double updateProjectPassedRate(Long projectId);
 
-    Double updateProjectProgress(Long projectId, List<TaskProgressDTO> taskList);
+    Double updateProjectProgress(Long projectId);
 }

--- a/src/main/java/com/ideality/coreflow/project/command/application/service/TaskService.java
+++ b/src/main/java/com/ideality/coreflow/project/command/application/service/TaskService.java
@@ -2,7 +2,6 @@ package com.ideality.coreflow.project.command.application.service;
 
 import com.ideality.coreflow.project.command.application.dto.RequestTaskDTO;
 
-import com.ideality.coreflow.project.query.dto.TaskProgressDTO;
 import java.util.List;
 
 public interface TaskService {
@@ -18,5 +17,5 @@ public interface TaskService {
 
     void validateTask(Long taskId);
 
-    Double updateTaskProgress(Long taskId, List<TaskProgressDTO> workList);
+    Double updateTaskProgress(Long taskId);
 }

--- a/src/main/java/com/ideality/coreflow/project/command/application/service/facade/ProjectFacadeService.java
+++ b/src/main/java/com/ideality/coreflow/project/command/application/service/facade/ProjectFacadeService.java
@@ -66,16 +66,12 @@ public class ProjectFacadeService {
     private final ProjectQueryService projectQueryService;
 
     public Double updateProgressRate(Long taskId) {
-        List<TaskProgressDTO> workList = workQueryService.getDetailProgressByTaskId(taskId);
-        System.out.println("workList.size() = " + workList.size());
-        return taskService.updateTaskProgress(taskId, workList);
+        return taskService.updateTaskProgress(taskId);
     }
 
     @Transactional
     public Double updateProjectProgressRate(Long projectId){
-        List<TaskProgressDTO> taskList = taskQueryService.getTaskProgressByProjectId(projectId);
-        System.out.println("taskList.size() = " + taskList.size());
-        return projectService.updateProjectProgress(projectId, taskList);
+        return projectService.updateProjectProgress(projectId);
     }
 
     @Transactional

--- a/src/main/java/com/ideality/coreflow/project/command/application/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/com/ideality/coreflow/project/command/application/service/impl/ProjectServiceImpl.java
@@ -8,6 +8,7 @@ import com.ideality.coreflow.project.command.domain.aggregate.Status;
 import com.ideality.coreflow.project.command.domain.repository.ProjectRepository;
 import com.ideality.coreflow.project.command.application.dto.ProjectCreateRequest;
 import com.ideality.coreflow.project.query.dto.TaskProgressDTO;
+import com.ideality.coreflow.project.query.service.TaskQueryService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -24,6 +25,7 @@ import static com.ideality.coreflow.common.exception.ErrorCode.PROJECT_NOT_FOUND
 public class ProjectServiceImpl implements ProjectService {
     private final ProjectRepository projectRepository;
     private final HolidayQueryService holidayQueryService;
+    private final TaskQueryService taskQueryService;
 
     @Override
     public void existsById(Long projectId) {
@@ -96,7 +98,8 @@ public class ProjectServiceImpl implements ProjectService {
     }
 
     @Override
-    public Double updateProjectProgress(Long projectId, List<TaskProgressDTO> taskList) {
+    public Double updateProjectProgress(Long projectId) {
+        List<TaskProgressDTO> taskList = taskQueryService.getTaskProgressByProjectId(projectId);
         Project project = projectRepository.findById(projectId).orElseThrow(() -> new BaseException(PROJECT_NOT_FOUND));
         System.out.println("project = " + project);
         Long totalDuration = 0L;

--- a/src/main/java/com/ideality/coreflow/project/command/application/service/impl/TaskServiceImpl.java
+++ b/src/main/java/com/ideality/coreflow/project/command/application/service/impl/TaskServiceImpl.java
@@ -3,11 +3,14 @@ package com.ideality.coreflow.project.command.application.service.impl;
 import com.ideality.coreflow.common.exception.BaseException;
 import com.ideality.coreflow.holiday.query.service.HolidayQueryService;
 import com.ideality.coreflow.project.command.application.dto.RequestTaskDTO;
+import com.ideality.coreflow.project.command.application.service.ProjectService;
 import com.ideality.coreflow.project.command.application.service.TaskService;
+import com.ideality.coreflow.project.command.application.service.facade.ProjectFacadeService;
 import com.ideality.coreflow.project.command.domain.aggregate.Status;
 import com.ideality.coreflow.project.command.domain.aggregate.Work;
 import com.ideality.coreflow.project.command.domain.repository.TaskRepository;
 import com.ideality.coreflow.project.query.dto.TaskProgressDTO;
+import com.ideality.coreflow.project.query.service.WorkQueryService;
 import com.ideality.coreflow.template.query.dto.NodeDTO;
 
 import java.time.LocalDate;
@@ -28,6 +31,8 @@ public class TaskServiceImpl implements TaskService {
 
     private final TaskRepository taskRepository;
     private final HolidayQueryService holidayQueryService;
+    private final ProjectService projectService;
+    private final WorkQueryService workQueryService;
 
     @Override
     @Transactional
@@ -103,7 +108,8 @@ public class TaskServiceImpl implements TaskService {
     }
 
     @Override
-    public Double updateTaskProgress(Long taskId, List<TaskProgressDTO> workList) {
+    public Double updateTaskProgress(Long taskId) {
+        List<TaskProgressDTO> workList = workQueryService.getDetailProgressByTaskId(taskId);
         Work task = taskRepository.findById(taskId).orElseThrow(() -> new BaseException(TASK_NOT_FOUND));
         Long totalDuration = 0L;
         Double totalProgress = 0.0;
@@ -121,6 +127,10 @@ public class TaskServiceImpl implements TaskService {
         System.out.println("Num to Save = " + Math.round(totalProgress/totalDuration*10000)/100.0);
         task.setProgressRate(Math.round(totalProgress/totalDuration*10000)/100.0);
         taskRepository.saveAndFlush(task);
+
+        // 프로젝트 진척률도 수정
+        projectService.updateProjectProgress(task.getProjectId());
+
         return task.getProgressRate();
     }
 }


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.
- 태스크의 진척률 업데이트 시 업데이트된 태스크의 진척률을 반영하여 프로젝트의 진척률도 자동으로 계산됨

## 📌 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 🌿 작업한 브랜치 (Working Branch)
> 예: `feature/게시글-작성`
feature/project/command-progress

- 현재 PR이 어떤 브랜치에서 작업되었는지 명시해주세요.
- feature/project/command-progress

## 📂 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요. (`#이슈번호`)
- close #142 

## 💡 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)
순환 참조 문제로 파사드를 서비스에서 가져다 쓸 수 없어서 파사드에서 수행하던 기능을 서비스로 이동시킴.
근데 이러면 파사드 구조를 위반하는 것 같은데 일단 진행시킴

## 📎 기타 참고 사항
- 코드 리뷰 중점적으로 봐줬으면 하는 부분
- 구현 중 고민된 점 등

@Hailyee 
taskService.updateTaskProgress(taskId);
세부일정 진척률 업데이트 할 때 이 코드 가져다 쓰면 됩니다
taskId 대신에 work.getParentTaskId(); ㅇㅇ

## 📸 스크린샷 (선택)
UI 관련 변경사항이 있다면 스크린샷을 첨부해주세요.