### PR TITLE
feat: 파이프라인 조회에 warning 추가

### DIFF
--- a/src/main/java/com/ideality/coreflow/project/query/dto/NodeDTO.java
+++ b/src/main/java/com/ideality/coreflow/project/query/dto/NodeDTO.java
@@ -28,5 +28,6 @@ public class NodeDTO {
     private Integer passedRate;
     private Integer delayDays;
     private String status;
+    private Boolean warning;
     private List<DeptDTO> deptList;
 }

--- a/src/main/java/com/ideality/coreflow/project/query/mapper/WorkMapper.java
+++ b/src/main/java/com/ideality/coreflow/project/query/mapper/WorkMapper.java
@@ -45,4 +45,5 @@ public interface WorkMapper {
 
     List<Long> selectWorkIdsByParentTaskId(Long parentTaskId);
 
+    List<Work> selectTaskByParentTaskId(Long parentTaskId);
 }

--- a/src/main/java/com/ideality/coreflow/project/query/service/WorkQueryService.java
+++ b/src/main/java/com/ideality/coreflow/project/query/service/WorkQueryService.java
@@ -1,11 +1,13 @@
 package com.ideality.coreflow.project.query.service;
 
 
+import com.ideality.coreflow.project.command.domain.aggregate.Work;
 import com.ideality.coreflow.project.query.dto.DeptWorkDTO;
 import com.ideality.coreflow.project.query.dto.DetailDTO;
 import com.ideality.coreflow.project.query.dto.TaskProgressDTO;
 import com.ideality.coreflow.project.query.dto.WorkDetailDTO;
 
+import java.util.Date;
 import java.util.List;
 
 public interface WorkQueryService {
@@ -27,4 +29,6 @@ public interface WorkQueryService {
     List<TaskProgressDTO> getDetailProgressByTaskId(Long taskId);
 
     List<Long> selectWorkIdsByParentTaskId(Long parentTaskId);
+
+    List<Work> getSubTasksByParentTaskId(Long id);
 }

--- a/src/main/java/com/ideality/coreflow/project/query/service/impl/WorkQueryServiceImpl.java
+++ b/src/main/java/com/ideality/coreflow/project/query/service/impl/WorkQueryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.ideality.coreflow.project.query.service.impl;
 
+import com.ideality.coreflow.project.command.domain.aggregate.Work;
 import com.ideality.coreflow.project.query.dto.DeptWorkDTO;
 import com.ideality.coreflow.project.query.dto.DetailDTO;
 import com.ideality.coreflow.project.query.dto.ParticipantDTO;
@@ -7,6 +8,7 @@ import com.ideality.coreflow.project.query.dto.TaskProgressDTO;
 import com.ideality.coreflow.project.query.dto.WorkDetailDTO;
 import com.ideality.coreflow.project.query.mapper.WorkMapper;
 import com.ideality.coreflow.project.query.service.WorkQueryService;
+import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -97,5 +99,10 @@ public class WorkQueryServiceImpl implements WorkQueryService {
     @Override
     public List<Long> selectWorkIdsByParentTaskId(Long parentTaskId) {
         return workMapper.selectWorkIdsByParentTaskId(parentTaskId);
+    }
+
+    @Override
+    public List<Work> getSubTasksByParentTaskId(Long parentTaskId) {
+        return workMapper.selectTaskByParentTaskId(parentTaskId);
     }
 }

--- a/src/main/resources/mapper/WorkMapper.xml
+++ b/src/main/resources/mapper/WorkMapper.xml
@@ -188,4 +188,27 @@
          WHERE parent_task_id = #{taskId}
     </select>
 
+    <select id="selectTaskByParentTaskId" resultType="com.ideality.coreflow.project.command.domain.aggregate.Work">
+        SELECT
+               id
+             , name
+             , description
+             , created_at
+             , start_base
+             , end_base
+             , start_expect
+             , end_expect
+             , start_real
+             , end_real
+             , progress_rate
+             , passed_rate
+             , delay_days
+             , status
+             , slack_time
+             , parent_task_id
+             , project_id
+          FROM work
+         WHERE parent_task_id = #{parentTaskId}
+    </select>
+
 </mapper>


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.
![✅ 프로젝트 파이프라인 페이지](https://github.com/user-attachments/assets/8c2bf334-6a9b-4fd8-a388-9ceb9922a5a1)
파이프라인 페이지에서 '태스크 예상 마감일' 보다 '세부일정 예상 마감일' 이 늦은 태스크에 대해 ui를 다르게 표시하기 위해 응답에 boolean 값으로 warning을 추가하였습니다

## 📌 변경 사항 (Changes)
- [ ] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 🌿 작업한 브랜치 (Working Branch)
> 예: `feature/게시글-작성`

- 현재 PR이 어떤 브랜치에서 작업되었는지 명시해주세요.
-

## 📂 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요. (`#이슈번호`)

## 💡 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)

## 📎 기타 참고 사항
- 코드 리뷰 중점적으로 봐줬으면 하는 부분
- 구현 중 고민된 점 등
- https://www.notion.so/ohgiraffers/api-projects-projectId-pipeline-20d649136c11802f9548f8702b963ad1?source=copy_link

## 📸 스크린샷 (선택)
UI 관련 변경사항이 있다면 스크린샷을 첨부해주세요.