### PR TITLE
[FEAT] 태스크 내 댓글에서 올린 자료 조회 기능 구현

### DIFF
--- a/src/main/java/com/ideality/coreflow/attachment/query/controller/AttachmentQueryController.java
+++ b/src/main/java/com/ideality/coreflow/attachment/query/controller/AttachmentQueryController.java
@@ -2,7 +2,9 @@ package com.ideality.coreflow.attachment.query.controller;
 
 import java.util.List;
 
+import com.ideality.coreflow.attachment.query.dto.ResponseCommentAttachmentDTO;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,5 +34,17 @@ public class AttachmentQueryController {
 
 		return ResponseEntity.ok(APIResponse.success(response, "프로젝트에 대한 산출물 조회 성공"));
 
+	}
+
+	// 태스크에 올라간 서류 조회
+	@GetMapping("/task/{taskId}/attachment/list")
+	public ResponseEntity<APIResponse<List<ResponseCommentAttachmentDTO>>>
+		getAttachmentsByTaskId(@PathVariable Long taskId) {
+		Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+
+		List<ResponseCommentAttachmentDTO> response =
+				attachmentQueryService.getAttachmentsByTaskId(taskId, userId);
+
+		return ResponseEntity.ok(APIResponse.success(response, "태스크에 올린 첨부파일(댓글) 조회 성공"));
 	}
 }

--- a/src/main/java/com/ideality/coreflow/attachment/query/dto/ResponseCommentAttachmentDTO.java
+++ b/src/main/java/com/ideality/coreflow/attachment/query/dto/ResponseCommentAttachmentDTO.java
@@ -1,0 +1,22 @@
+package com.ideality.coreflow.attachment.query.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+public class ResponseCommentAttachmentDTO {
+    private Long attachmentId;
+    private String originName;
+    private String url;
+    private String fileType;
+    private LocalDateTime uploadAt;
+    private Long userId;
+    private String userName;
+    private String deptName;
+}

--- a/src/main/java/com/ideality/coreflow/attachment/query/mapper/AttachmentMapper.java
+++ b/src/main/java/com/ideality/coreflow/attachment/query/mapper/AttachmentMapper.java
@@ -3,6 +3,7 @@ package com.ideality.coreflow.attachment.query.mapper;
 import java.util.List;
 import java.util.Map;
 
+import com.ideality.coreflow.attachment.query.dto.ResponseCommentAttachmentDTO;
 import org.apache.ibatis.annotations.Mapper;
 
 import com.ideality.coreflow.attachment.query.dto.ReportAttachmentDTO;
@@ -15,4 +16,5 @@ public interface AttachmentMapper {
 
 	List<ReportAttachmentDTO> selectAttachmentsByProjectId(Long projectId);
 
+	List<ResponseCommentAttachmentDTO> selectAttachmentsByTaskId(Long taskId);
 }

--- a/src/main/java/com/ideality/coreflow/attachment/query/service/AttachmentQueryService.java
+++ b/src/main/java/com/ideality/coreflow/attachment/query/service/AttachmentQueryService.java
@@ -3,6 +3,7 @@ package com.ideality.coreflow.attachment.query.service;
 import java.util.List;
 import java.util.Map;
 
+import com.ideality.coreflow.attachment.query.dto.ResponseCommentAttachmentDTO;
 import org.springframework.stereotype.Service;
 
 import com.ideality.coreflow.attachment.command.domain.aggregate.FileTargetType;
@@ -43,6 +44,16 @@ public class AttachmentQueryService {
 	// 프로젝트 산출물 내역 가져오기
 	public List<ReportAttachmentDTO> getAttachmentsByProjectId(Long projectId) {
 		List<ReportAttachmentDTO> response = attachmentMapper.selectAttachmentsByProjectId(projectId);
+
+		if (response == null) {
+			log.warn("첨부파일 조회 실패");
+			throw new BaseException(ErrorCode.ATTCHMENT_NOT_FOUND);
+		}
+		return response;
+	}
+
+	public List<ResponseCommentAttachmentDTO> getAttachmentsByTaskId(Long taskId, Long userId) {
+		List<ResponseCommentAttachmentDTO> response = attachmentMapper.selectAttachmentsByTaskId(taskId);
 
 		if (response == null) {
 			log.warn("첨부파일 조회 실패");

--- a/src/main/resources/mapper/AttachmentMapper.xml
+++ b/src/main/resources/mapper/AttachmentMapper.xml
@@ -14,6 +14,17 @@
         <result property="targetId" column="TARGET_ID"/>
     </resultMap>
 
+    <resultMap id="AttachmentCommentResultMap" type="com.ideality.coreflow.attachment.query.dto.ResponseCommentAttachmentDTO">
+        <id property="attachmentId" column="id"/>
+        <result property="originName" column="origin_name"/>
+        <result property="url" column="url"/>
+        <result property="fileType" column="file_type"/>
+        <result property="uploadAt" column="upload_at"/>
+        <result property="userId" column="uploader_id"/>
+        <result property="userName" column="name"/>
+        <result property="deptName" column="dept_name"/>
+    </resultMap>
+
     <select id="selectUrl" parameterType="map" resultMap="AttachmentResultMap">
         SELECT
             a.id,
@@ -47,6 +58,22 @@
         WHERE a.target_type = 'PROJECT'
           AND a.target_id = #{projectId}
           AND a.is_deleted = FALSE
+    </select>
+
+    <select id="selectAttachmentsByTaskId" parameterType="long" resultMap="AttachmentCommentResultMap">
+        SELECT
+               a.id
+             , a.origin_name
+             , a.url
+             , a.file_type
+             , a.upload_at
+             , a.uploader_id
+             , b.name
+             , b.dept_name
+          FROM attachment a
+          JOIN user b ON a.uploader_id = b.id
+         WHERE a.target_id = #{taskId}
+           AND a.target_type = 'COMMENT'
     </select>
 
 </mapper>

--- a/src/main/resources/sql/DDL.sql
+++ b/src/main/resources/sql/DDL.sql
@@ -1,3 +1,7 @@
+DROP DATABASE IF EXISTS company_a;
+
+CREATE DATABASE company_a;
+USE company_a;
 -- 회원
 CREATE TABLE user (
     id BIGINT PRIMARY KEY AUTO_INCREMENT,

--- a/src/main/resources/sql/DummyData.sql
+++ b/src/main/resources/sql/DummyData.sql
@@ -112,37 +112,6 @@ VALUES
     '본부장'
 );
 
-INSERT INTO role
-(name, type)
-VALUES
-(
-    'DIRECTOR', 'PROJECT'
-),
-(
-    'TEAM_LEADER', 'PROJECT'
-),
-(
-    'TEAM_MEMBER', 'PROJECT'
-),
-(
-    'ADMIN', 'GENERAL'
-),
-(
-    'VIEWER', 'PROJECT'
-),
-(
-    'ASSIGNEE', 'PROJECT'
-),
-(
-    'PARTICIPANT', 'PROJECT'
-),
-(
-    'CREATOR', 'GENERAL'
-),
-(
-    'PARTNER', 'GENERAL'
-)
-;
 
 INSERT INTO project
 (
@@ -204,26 +173,3 @@ VALUES
     7,
     2
 );
-
-
-INSERT INTO job_rank (name)
-VALUES ("사원"),
-       ("대리"),
-       ("과장"),
-       ("차장"),
-       ("부장"),
-       ("협력업체");
-
-INSERT INTO job_role (name)
-VALUES ("팀원"),
-       ("파트장"),
-       ("본부장"),
-       ("협력업체");
-
-
-INSERT INTO dept (name, dept_code)
-VALUES ("기획팀", "PM"),
-       ("디자인팀", "DES"),
-       ("소싱팀", "MD"),
-       ("생산팀", "MFG"),
-       ("협력업체", "PART");


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.
태스크에서 댓글을 통해 올린 자료를 조회할 수 있게 하여 해당 자료들을 가져올 수 있게 하는 API를 구현하였습니다.
DDL이 수정되어 있어서 DDL도 조금 수정하였습니다. (DB 다시 생성할 수 있게)

## 📌 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 🌿 작업한 브랜치 (Working Branch)
> 예: `feature/게시글-작성`

- 현재 PR이 어떤 브랜치에서 작업되었는지 명시해주세요.
- feature/attachment/query-comment

## 📂 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요. (`#이슈번호`)
- close #188 

## 💡 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)

## 📎 기타 참고 사항
- 코드 리뷰 중점적으로 봐줬으면 하는 부분
- 구현 중 고민된 점 등

## 📸 스크린샷 (선택)
UI 관련 변경사항이 있다면 스크린샷을 첨부해주세요.
<img width="972" alt="image" src="https://github.com/user-attachments/assets/16d35c8e-31b0-46cd-9a91-7e9c27de252a" />
