### PR TITLE
[REFACTOR] 댓글 조회에서 첨부파일도 받아오게 + 첨부파일 Target_id 전부 댓글 id로 되게

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # 설정 파일
-application.yml
+application-*.yml
 *.properties
 !gradle/wrapper/gradle-wrapper.properties
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 
-    // s3 버킷 연결을 위한 설정
+    // s3 버킷 연결을 위한 설정 -> v1
     implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.261')
     implementation 'com.amazonaws:aws-java-sdk-s3'
 
@@ -101,7 +101,10 @@ dependencies {
     implementation 'org.knowm.xchart:xchart:3.8.1'
     implementation 'org.jfree:jfreechart:1.5.3'
 
-
+    // ✅ presigned URL 생성을 위한 AWS SDK v2
+    implementation platform("software.amazon.awssdk:bom:2.25.3")
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:auth'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ideality/coreflow/attachment/query/controller/AttachmentQueryController.java
+++ b/src/main/java/com/ideality/coreflow/attachment/query/controller/AttachmentQueryController.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.ideality.coreflow.attachment.query.dto.AttachmentDownloadDTO;
 import com.ideality.coreflow.attachment.query.dto.ResponseCommentAttachmentDTO;
+import com.ideality.coreflow.attachment.query.service.AttachmentQueryFacadeService;
 import com.ideality.coreflow.infra.s3.S3Service;
 import org.springframework.http.*;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -28,6 +29,7 @@ public class AttachmentQueryController {
 
 	private final AttachmentQueryService attachmentQueryService;
 	private final S3Service s3Service;
+	private final AttachmentQueryFacadeService attachmentQueryFacadeService;
 
 	// 프로젝트의 산출물 목록 조회하기
 	@GetMapping("/project/{projectId}/attachment/list")
@@ -47,11 +49,12 @@ public class AttachmentQueryController {
 		Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
 
 		List<ResponseCommentAttachmentDTO> response =
-				attachmentQueryService.getAttachmentsByTaskId(taskId, userId);
+				attachmentQueryFacadeService.getAttachmentListByComment(taskId, userId);
 
 		return ResponseEntity.ok(APIResponse.success(response, "태스크에 올린 첨부파일(댓글) 조회 성공"));
 	}
 
+	/* 설명. 파일 다운로드 시켜주는 API */
 	@GetMapping("/attachment/{attachmentId}/download")
 	public ResponseEntity<byte[]> getPresignedDownloadUrl(@PathVariable Long attachmentId) {
 

--- a/src/main/java/com/ideality/coreflow/attachment/query/dto/AttachmentDownloadDTO.java
+++ b/src/main/java/com/ideality/coreflow/attachment/query/dto/AttachmentDownloadDTO.java
@@ -1,0 +1,14 @@
+package com.ideality.coreflow.attachment.query.dto;
+
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+public class AttachmentDownloadDTO {
+    private String url;
+    private String originName;
+}

--- a/src/main/java/com/ideality/coreflow/attachment/query/dto/AttachmentForCommentDTO.java
+++ b/src/main/java/com/ideality/coreflow/attachment/query/dto/AttachmentForCommentDTO.java
@@ -1,0 +1,15 @@
+package com.ideality.coreflow.attachment.query.dto;
+
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+public class AttachmentForCommentDTO {
+    private Long attachmentId;
+    private Long commentId;
+    private String originName;
+}

--- a/src/main/java/com/ideality/coreflow/attachment/query/dto/ResponseCommentAttachmentDTO.java
+++ b/src/main/java/com/ideality/coreflow/attachment/query/dto/ResponseCommentAttachmentDTO.java
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 public class ResponseCommentAttachmentDTO {
     private Long attachmentId;
     private String originName;
-    private String url;
     private String fileType;
     private LocalDateTime uploadAt;
     private Long userId;

--- a/src/main/java/com/ideality/coreflow/attachment/query/mapper/AttachmentMapper.java
+++ b/src/main/java/com/ideality/coreflow/attachment/query/mapper/AttachmentMapper.java
@@ -3,12 +3,8 @@ package com.ideality.coreflow.attachment.query.mapper;
 import java.util.List;
 import java.util.Map;
 
-import com.ideality.coreflow.attachment.query.dto.AttachmentDownloadDTO;
-import com.ideality.coreflow.attachment.query.dto.ResponseCommentAttachmentDTO;
+import com.ideality.coreflow.attachment.query.dto.*;
 import org.apache.ibatis.annotations.Mapper;
-
-import com.ideality.coreflow.attachment.query.dto.ReportAttachmentDTO;
-import com.ideality.coreflow.attachment.query.dto.ResponseAttachmentDTO;
 
 @Mapper
 public interface AttachmentMapper {
@@ -20,4 +16,8 @@ public interface AttachmentMapper {
 	List<ResponseCommentAttachmentDTO> selectAttachmentsByTaskId(Long taskId);
 
 	AttachmentDownloadDTO selectAttachmentInfoForDownload(Long attachmentId);
+
+	AttachmentForCommentDTO selectAttachmentsForComments(Long commentId);
+
+	List<ResponseCommentAttachmentDTO> selectAttachmentsByCommentId(List<Long> commentIds);
 }

--- a/src/main/java/com/ideality/coreflow/attachment/query/mapper/AttachmentMapper.java
+++ b/src/main/java/com/ideality/coreflow/attachment/query/mapper/AttachmentMapper.java
@@ -3,6 +3,7 @@ package com.ideality.coreflow.attachment.query.mapper;
 import java.util.List;
 import java.util.Map;
 
+import com.ideality.coreflow.attachment.query.dto.AttachmentDownloadDTO;
 import com.ideality.coreflow.attachment.query.dto.ResponseCommentAttachmentDTO;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -17,4 +18,6 @@ public interface AttachmentMapper {
 	List<ReportAttachmentDTO> selectAttachmentsByProjectId(Long projectId);
 
 	List<ResponseCommentAttachmentDTO> selectAttachmentsByTaskId(Long taskId);
+
+	AttachmentDownloadDTO selectAttachmentInfoForDownload(Long attachmentId);
 }

--- a/src/main/java/com/ideality/coreflow/attachment/query/service/AttachmentQueryFacadeService.java
+++ b/src/main/java/com/ideality/coreflow/attachment/query/service/AttachmentQueryFacadeService.java
@@ -1,0 +1,48 @@
+package com.ideality.coreflow.attachment.query.service;
+
+import com.ideality.coreflow.attachment.query.dto.ResponseCommentAttachmentDTO;
+import com.ideality.coreflow.comment.query.service.CommentQueryService;
+import com.ideality.coreflow.common.exception.BaseException;
+import com.ideality.coreflow.common.exception.ErrorCode;
+import com.ideality.coreflow.project.query.service.ParticipantQueryService;
+import com.ideality.coreflow.project.query.service.TaskQueryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static com.ideality.coreflow.common.exception.ErrorCode.TASK_NOT_FOUND;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AttachmentQueryFacadeService {
+    private final AttachmentQueryService attachmentQueryService;
+    private final CommentQueryService commentQueryService;
+    private final TaskQueryService taskQueryService;
+    private final ParticipantQueryService participantQueryService;
+
+    public List<ResponseCommentAttachmentDTO> getAttachmentListByComment(Long taskId, Long userId) {
+
+        /* 설명. 일단 프로젝트 참여자인지 확인 */
+        Long projectId = taskQueryService.getProjectId(taskId);
+
+        /* 설명. 잘못된 접근에 대한 예외처리 */
+        if (projectId == null) {
+            throw new BaseException(TASK_NOT_FOUND);
+        }
+
+        /* 설명. 프로젝트 참여자 -> 댓글을 작성할 수 있는 권한이 있는가 */
+        boolean isParticipant = participantQueryService.isParticipant(userId, projectId);
+
+        if (!isParticipant) {
+            throw new BaseException(ErrorCode.NOT_COMMENT_WRITER);
+        }
+
+        /* 설명. 하나의 태스크 안에 있는 모든 댓글별 첨부파일 조회 */
+        List<Long> commentIds = commentQueryService.selectAllCommentsByAttachment(taskId);
+
+        return attachmentQueryService.getAttachmentsByCommentId(commentIds);
+    }
+}

--- a/src/main/java/com/ideality/coreflow/attachment/query/service/AttachmentQueryService.java
+++ b/src/main/java/com/ideality/coreflow/attachment/query/service/AttachmentQueryService.java
@@ -1,17 +1,15 @@
 package com.ideality.coreflow.attachment.query.service;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.ideality.coreflow.attachment.query.dto.AttachmentDownloadDTO;
-import com.ideality.coreflow.attachment.query.dto.ResponseCommentAttachmentDTO;
+import com.ideality.coreflow.attachment.query.dto.*;
 import com.ideality.coreflow.infra.s3.S3Service;
 import org.springframework.stereotype.Service;
 
 import com.ideality.coreflow.attachment.command.domain.aggregate.FileTargetType;
-import com.ideality.coreflow.attachment.query.dto.ReportAttachmentDTO;
-import com.ideality.coreflow.attachment.query.dto.ResponseAttachmentDTO;
 import com.ideality.coreflow.attachment.query.mapper.AttachmentMapper;
 import com.ideality.coreflow.common.exception.BaseException;
 import com.ideality.coreflow.common.exception.ErrorCode;
@@ -56,19 +54,31 @@ public class AttachmentQueryService {
 		return response;
 	}
 
-	/* 설명. 댓글에 올라온 첨부 파일 조회 */
-	public List<ResponseCommentAttachmentDTO> getAttachmentsByTaskId(Long taskId, Long userId) {
-		List<ResponseCommentAttachmentDTO> response = attachmentMapper.selectAttachmentsByTaskId(taskId);
 
-		if (response == null) {
-			log.warn("첨부파일 조회 실패");
-			throw new BaseException(ErrorCode.ATTCHMENT_NOT_FOUND);
+	public AttachmentDownloadDTO getAttachmentDownload(Long attachmentId) {
+		return attachmentMapper.selectAttachmentInfoForDownload(attachmentId);
+	}
+
+	/* 설명. 댓글에 필요한 첨부 파일 가져오기 */
+	public List<AttachmentForCommentDTO> selectAttachments(List<Long> commentIds) {
+		List<AttachmentForCommentDTO> response = new ArrayList<>();
+
+		for (Long commentId : commentIds) {
+			AttachmentForCommentDTO attachment = attachmentMapper.selectAttachmentsForComments(commentId);
+			response.add(attachment);
 		}
 
 		return response;
 	}
 
-	public AttachmentDownloadDTO getAttachmentDownload(Long attachmentId) {
-		return attachmentMapper.selectAttachmentInfoForDownload(attachmentId);
+	/* 설명. 태스크에 모든 댓글에 따라서 조회를 해오기 */
+	public List<ResponseCommentAttachmentDTO> getAttachmentsByCommentId(List<Long> commentIds) {
+		return attachmentMapper.selectAttachmentsByCommentId(commentIds);
+	}
+
+
+	/* 설명. 댓글 수정에서 사용 */
+	public AttachmentForCommentDTO selectBycommentId(Long commentId) {
+		return attachmentMapper.selectAttachmentsForComments(commentId);
 	}
 }

--- a/src/main/java/com/ideality/coreflow/attachment/query/service/AttachmentQueryService.java
+++ b/src/main/java/com/ideality/coreflow/attachment/query/service/AttachmentQueryService.java
@@ -1,9 +1,12 @@
 package com.ideality.coreflow.attachment.query.service;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
+import com.ideality.coreflow.attachment.query.dto.AttachmentDownloadDTO;
 import com.ideality.coreflow.attachment.query.dto.ResponseCommentAttachmentDTO;
+import com.ideality.coreflow.infra.s3.S3Service;
 import org.springframework.stereotype.Service;
 
 import com.ideality.coreflow.attachment.command.domain.aggregate.FileTargetType;
@@ -23,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AttachmentQueryService {
 
 	private final AttachmentMapper attachmentMapper;
+	private final S3Service s3Service;
 
 	// TARGET TYPE, TARGET ID 로 URL 가져오기
 	public String getUrl(Long templateId, FileTargetType targetType) {
@@ -52,6 +56,7 @@ public class AttachmentQueryService {
 		return response;
 	}
 
+	/* 설명. 댓글에 올라온 첨부 파일 조회 */
 	public List<ResponseCommentAttachmentDTO> getAttachmentsByTaskId(Long taskId, Long userId) {
 		List<ResponseCommentAttachmentDTO> response = attachmentMapper.selectAttachmentsByTaskId(taskId);
 
@@ -59,6 +64,11 @@ public class AttachmentQueryService {
 			log.warn("첨부파일 조회 실패");
 			throw new BaseException(ErrorCode.ATTCHMENT_NOT_FOUND);
 		}
+
 		return response;
+	}
+
+	public AttachmentDownloadDTO getAttachmentDownload(Long attachmentId) {
+		return attachmentMapper.selectAttachmentInfoForDownload(attachmentId);
 	}
 }

--- a/src/main/java/com/ideality/coreflow/comment/command/application/service/facade/CommentFacadeService.java
+++ b/src/main/java/com/ideality/coreflow/comment/command/application/service/facade/CommentFacadeService.java
@@ -108,7 +108,7 @@ public class CommentFacadeService {
 
             CreateAttachmentDTO attachmentDTO = new CreateAttachmentDTO(uploadResult);
             attachmentCommandService.createAttachmentForComment(attachmentDTO,
-                    taskId,
+                    commentId,
                     userId);
         }
         return commentId;

--- a/src/main/java/com/ideality/coreflow/comment/query/controller/CommentQueryController.java
+++ b/src/main/java/com/ideality/coreflow/comment/query/controller/CommentQueryController.java
@@ -21,7 +21,6 @@ import java.util.List;
 public class CommentQueryController {
 
     private final CommentQueryFacadeService commentQueryFacadeService;
-    private final CommentQueryService commentQueryService;
 
     @GetMapping("/task/{taskId}")
     public ResponseEntity<APIResponse<List<SelectCommentDTO>>>
@@ -35,7 +34,7 @@ public class CommentQueryController {
     @GetMapping("/{commentId}")
     public ResponseEntity<APIResponse<ResponseCommentForModifyDTO>> getCommentContent(@PathVariable Long commentId) {
         Long userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
-        ResponseCommentForModifyDTO resDTO = commentQueryService.selectComment(commentId, userId);
+        ResponseCommentForModifyDTO resDTO = commentQueryFacadeService.selectComment(commentId, userId);
         return ResponseEntity.ok(APIResponse.success(resDTO, "댓글 내용 조회에 성공하였습니다."));
     }
 

--- a/src/main/java/com/ideality/coreflow/comment/query/dto/ResponseCommentForModifyDTO.java
+++ b/src/main/java/com/ideality/coreflow/comment/query/dto/ResponseCommentForModifyDTO.java
@@ -13,4 +13,7 @@ public class ResponseCommentForModifyDTO {
     private String content;
     private Boolean isNotice;
     private Long userId;
+
+    private Long attachmentId;
+    private String originName;
 }

--- a/src/main/java/com/ideality/coreflow/comment/query/dto/SelectCommentDTO.java
+++ b/src/main/java/com/ideality/coreflow/comment/query/dto/SelectCommentDTO.java
@@ -20,4 +20,7 @@ public class SelectCommentDTO {
     private String content;
     private LocalDateTime createdAt;
     private Boolean isModify;
+
+    private Long attachmentId;
+    private String originName;
 }

--- a/src/main/java/com/ideality/coreflow/comment/query/mapper/CommentMapper.java
+++ b/src/main/java/com/ideality/coreflow/comment/query/mapper/CommentMapper.java
@@ -13,4 +13,6 @@ public interface CommentMapper {
     ResponseCommentForModifyDTO selectCommentByModify(Long commentId);
 
     List<SelectCommentDTO> selectNotices(Long taskId);
+
+    List<Long> selectAllComments(Long taskId);
 }

--- a/src/main/java/com/ideality/coreflow/comment/query/service/CommentQueryService.java
+++ b/src/main/java/com/ideality/coreflow/comment/query/service/CommentQueryService.java
@@ -11,4 +11,6 @@ public interface CommentQueryService {
     ResponseCommentForModifyDTO selectComment(Long commentId, Long userId);
 
     List<SelectCommentDTO> selectNotices(Long taskId);
+
+    List<Long> selectAllCommentsByAttachment(Long taskId);
 }

--- a/src/main/java/com/ideality/coreflow/comment/query/service/facade/CommentQueryFacadeService.java
+++ b/src/main/java/com/ideality/coreflow/comment/query/service/facade/CommentQueryFacadeService.java
@@ -1,6 +1,9 @@
 package com.ideality.coreflow.comment.query.service.facade;
 
+import com.ideality.coreflow.attachment.query.dto.AttachmentForCommentDTO;
+import com.ideality.coreflow.attachment.query.service.AttachmentQueryService;
 import com.ideality.coreflow.comment.command.application.service.CommentService;
+import com.ideality.coreflow.comment.query.dto.ResponseCommentForModifyDTO;
 import com.ideality.coreflow.comment.query.dto.SelectCommentDTO;
 import com.ideality.coreflow.comment.query.service.CommentQueryService;
 import com.ideality.coreflow.common.exception.BaseException;
@@ -13,16 +16,19 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class CommentQueryFacadeService {
 
-    private final CommentService commentService;
     private final CommentQueryService commentQueryService;
     private final TaskQueryService taskQueryService;
     private final ParticipantQueryService participantQueryService;
+    private final AttachmentQueryService attachmentQueryService;
 
 
     public List<SelectCommentDTO> selectComments(Long taskId, Long userId) {
@@ -35,10 +41,42 @@ public class CommentQueryFacadeService {
             throw new BaseException(ErrorCode.ACCESS_DENIED);
         }
 
+        /* 설명. 댓글 조회 */
+        List<SelectCommentDTO> commentList = commentQueryService.selectComments(taskId);
+
+        /* 설명. 댓글 Id 필터링 */
+        List<Long> commentIds = commentList.stream()
+                .map(SelectCommentDTO::getCommentId)
+                .collect(Collectors.toList());
+
+        log.info("Select comments for task {}, comment ids {}", taskId, commentIds);
+
+        /* 설명. 첨부파일 조회? */
+        List<AttachmentForCommentDTO> attachments = attachmentQueryService.selectAttachments(commentIds);
+        log.info("Select comments for {} attachments", attachments);
+
+        for (int i = 0; i < commentList.size(); i++) {
+            SelectCommentDTO comment = commentList.get(i);
+            log.info("Select comment {}", comment);
+
+            if (i < attachments.size()) {
+                AttachmentForCommentDTO attachment = attachments.get(i);
+
+                if (attachment != null && attachment.getCommentId() != null &&
+                        attachment.getCommentId().equals(comment.getCommentId())) {
+                    log.info("Select attachment for comment {}", comment.getCommentId());
+                    comment.setAttachmentId(attachment.getAttachmentId());
+                    log.info("Select attachmentid {}", attachment.getAttachmentId());
+                    comment.setOriginName(attachment.getOriginName());
+                }
+            }
+        }
         // 검증 끝나면, 해당 댓글 찾아오기
-        return commentQueryService.selectComments(taskId);
+        return commentList;
     }
 
+
+    /* 설명. 공지 조회해오기 */
     public List<SelectCommentDTO> selectNotices(Long taskId, Long userId) {
         // 태스크에 따른 projectId 가져오기 + 예외 검사 (잘못된 태스크 Id)
         Long projectId = taskQueryService.selectProjectIdByTaskId(taskId);
@@ -49,7 +87,46 @@ public class CommentQueryFacadeService {
             throw new BaseException(ErrorCode.ACCESS_DENIED);
         }
 
-        // 검증 끝나면, 해당 댓글 찾아오기
-        return commentQueryService.selectNotices(taskId);
+        List<SelectCommentDTO> selectNoticeList = commentQueryService.selectNotices(taskId);
+
+
+        /* 설명. 댓글 Id 필터링 */
+        List<Long> commentIds = selectNoticeList.stream()
+                .map(SelectCommentDTO::getCommentId)
+                .collect(Collectors.toList());
+
+
+        /* 설명. 첨부파일 조회? */
+        List<AttachmentForCommentDTO> attachments = attachmentQueryService.selectAttachments(commentIds);
+        log.info("Select comments for {} attachments", attachments);
+
+        for (int i = 0; i < selectNoticeList.size(); i++) {
+            SelectCommentDTO comment = selectNoticeList.get(i);
+
+            if (i < attachments.size()) {
+                AttachmentForCommentDTO attachment = attachments.get(i);
+
+                if (attachment != null && attachment.getCommentId() != null &&
+                        attachment.getCommentId().equals(comment.getCommentId())) {
+                    log.info("Select attachment for comment {}", comment.getCommentId());
+                    comment.setAttachmentId(attachment.getAttachmentId());
+                    log.info("Select attachmentid {}", attachment.getAttachmentId());
+                    comment.setOriginName(attachment.getOriginName());
+                }
+            }
+        }
+        // 검증 끝나면, 해당 공자 찾아오기
+        return selectNoticeList;
+    }
+
+    /* 설명. 수정을 위해 전부 불러오는 부분 */
+    public ResponseCommentForModifyDTO selectComment(Long commentId, Long userId) {
+        ResponseCommentForModifyDTO resDTO = commentQueryService.selectComment(commentId, userId);
+        AttachmentForCommentDTO attachment = attachmentQueryService.selectBycommentId(resDTO.getCommentId());
+
+        resDTO.setAttachmentId(attachment.getAttachmentId());
+        resDTO.setOriginName(attachment.getOriginName());
+
+        return resDTO;
     }
 }

--- a/src/main/java/com/ideality/coreflow/comment/query/service/impl/CommentQueryServiceImpl.java
+++ b/src/main/java/com/ideality/coreflow/comment/query/service/impl/CommentQueryServiceImpl.java
@@ -42,4 +42,9 @@ public class CommentQueryServiceImpl implements CommentQueryService {
     public List<SelectCommentDTO> selectNotices(Long taskId) {
         return commentMapper.selectNotices(taskId);
     }
+
+    @Override
+    public List<Long> selectAllCommentsByAttachment(Long taskId) {
+        return commentMapper.selectAllComments(taskId);
+    }
 }

--- a/src/main/java/com/ideality/coreflow/infra/s3/S3Service.java
+++ b/src/main/java/com/ideality/coreflow/infra/s3/S3Service.java
@@ -7,19 +7,26 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.UUID;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class S3Service {
-    @Autowired
-    private AmazonS3 amazonS3Client;
+    private final AmazonS3 amazonS3Client;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
@@ -27,7 +34,7 @@ public class S3Service {
     /* 설명. 프로필 이미지 만들기 */
     public String uploadImage(MultipartFile file, String folder) {
         /* 설명. uuid로 파일명을 충돌나지 않게 수정 */
-        String fileName = generateFileName(file);           // uuid.jpg
+        String fileName = generateFileName();           // uuid.jpg
         String key = generateKey(fileName, folder);          // profile-image/uuid.jpg
         try {
             ObjectMetadata metadata = new ObjectMetadata();
@@ -44,8 +51,9 @@ public class S3Service {
         }
     }
 
-    public String generateFileName(MultipartFile file) {
-        return UUID.randomUUID().toString() + "-" + file.getOriginalFilename();
+    /* 설명. 한글이 들어가면 presigned-url을 써도 깨지게 되는 문제 발생(uuid로만) */
+    public String generateFileName() {
+        return UUID.randomUUID().toString();
     }
 
     private String generateKey(String fileName, String folder) {
@@ -86,7 +94,7 @@ public class S3Service {
     }
 
     // S3 URL → key 추출 (경로만)
-    private String extractS3KeyFromUrl(String url) {
+    public String extractS3KeyFromUrl(String url) {
         if (url == null || !url.contains(".com/")) {
             throw new IllegalArgumentException("S3 URL 형식이 잘못되었습니다: " + url);
         }
@@ -95,18 +103,24 @@ public class S3Service {
 
     /* 설명. 결재 서류 + 댓글 파일용 업로더 */
     public UploadFileResult uploadFile(MultipartFile file, String folder) {
-        /* 설명. uuid로 파일명을 충돌나지 않게 수정 */
-        String originName = file.getOriginalFilename();
-        String storedName = generateFileName(file);           // uuid.jpg
-        String key = generateKey(storedName, folder);          // profile-image/uuid.jpg
+        String originName = file.getOriginalFilename();             // 원본 파일명
+        String storedName = generateFileName();                     // UUID 저장용 파일명
+        String key = generateKey(storedName, folder);               // ex) comment-docs/uuid
+
         try {
             ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentType(file.getContentType());
             metadata.setContentLength(file.getSize());
 
+            // ✅ 다운로드 시 원본 파일명으로 내려받게 설정
+            String encodedFileName = java.net.URLEncoder.encode(originName, StandardCharsets.UTF_8)
+                    .replaceAll("\\+", "%20"); // 공백 처리
+            metadata.setContentDisposition("attachment; filename*=UTF-8''" + encodedFileName);
+
             amazonS3Client.putObject(
                     new PutObjectRequest(bucketName, key, file.getInputStream(), metadata)
             );
+
             String url = amazonS3Client.getUrl(bucketName, key).toString();
 
             return new UploadFileResult(
@@ -118,6 +132,16 @@ public class S3Service {
             );
         } catch (IOException e) {
             throw new RuntimeException("파일 업로드 실패", e);
+        }
+    }
+
+    public byte[] getFileBytes(String key) {
+        try {
+            var s3Object = amazonS3Client.getObject(bucketName, key);
+            return s3Object.getObjectContent().readAllBytes();
+        } catch (IOException e) {
+            log.error("파일 다운로드 실패 - key: {}", key, e);
+            throw new RuntimeException("파일 다운로드 실패", e);
         }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: dev
+    active: deploy

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: deploy
+    active: dev

--- a/src/main/resources/mapper/AttachmentMapper.xml
+++ b/src/main/resources/mapper/AttachmentMapper.xml
@@ -17,7 +17,6 @@
     <resultMap id="AttachmentCommentResultMap" type="com.ideality.coreflow.attachment.query.dto.ResponseCommentAttachmentDTO">
         <id property="attachmentId" column="id"/>
         <result property="originName" column="origin_name"/>
-        <result property="url" column="url"/>
         <result property="fileType" column="file_type"/>
         <result property="uploadAt" column="upload_at"/>
         <result property="userId" column="uploader_id"/>
@@ -28,6 +27,12 @@
     <resultMap id="AttachmentDownloadMap" type="com.ideality.coreflow.attachment.query.dto.AttachmentDownloadDTO">
         <result property="url" column="url"/>
         <result property="originName" column="origin_name"/>
+    </resultMap>
+
+    <resultMap id="AttachForCommentMap" type="com.ideality.coreflow.attachment.query.dto.AttachmentForCommentDTO">
+        <id property="attachmentId" column="id"/>
+        <result property="originName" column="origin_name"/>
+        <result property="commentId" column="target_id"/>
     </resultMap>
 
     <select id="selectUrl" parameterType="map" resultMap="AttachmentResultMap">
@@ -65,28 +70,42 @@
           AND a.is_deleted = FALSE
     </select>
 
-    <select id="selectAttachmentsByTaskId" parameterType="long" resultMap="AttachmentCommentResultMap">
-        SELECT
-               a.id
-             , a.origin_name
-             , a.url
-             , a.file_type
-             , a.upload_at
-             , a.uploader_id
-             , b.name
-             , b.dept_name
-          FROM attachment a
-          JOIN user b ON a.uploader_id = b.id
-         WHERE a.target_id = #{taskId}
-           AND a.target_type = 'COMMENT'
-    </select>
-
-
     <select id="selectAttachmentInfoForDownload" parameterType="long" resultMap="AttachmentDownloadMap">
         SELECT
                url
              , origin_name
           FROM attachment
          WHERE id = #{attachmentId}
+    </select>
+
+    <select id="selectAttachmentsForComments" parameterType="long" resultMap="AttachForCommentMap">
+        SELECT
+               id
+             , origin_name
+             , target_id
+          FROM attachment
+         WHERE target_type = 'COMMENT'
+           AND target_id = #{commentId}
+    </select>
+
+    <select id="selectAttachmentsByCommentId"
+            parameterType="list"
+            resultMap="AttachmentCommentResultMap">
+        SELECT
+        a.id
+        , a.origin_name
+        , a.url
+        , a.file_type
+        , a.upload_at
+        , a.uploader_id
+        , b.name
+        , b.dept_name
+        FROM attachment a
+        JOIN user b ON a.uploader_id = b.id
+        WHERE a.target_id IN
+        <foreach collection="list" item="id" open="(" separator="," close=")">
+            #{id}
+        </foreach>
+        AND a.target_type = 'COMMENT'
     </select>
 </mapper>

--- a/src/main/resources/mapper/AttachmentMapper.xml
+++ b/src/main/resources/mapper/AttachmentMapper.xml
@@ -25,6 +25,11 @@
         <result property="deptName" column="dept_name"/>
     </resultMap>
 
+    <resultMap id="AttachmentDownloadMap" type="com.ideality.coreflow.attachment.query.dto.AttachmentDownloadDTO">
+        <result property="url" column="url"/>
+        <result property="originName" column="origin_name"/>
+    </resultMap>
+
     <select id="selectUrl" parameterType="map" resultMap="AttachmentResultMap">
         SELECT
             a.id,
@@ -76,4 +81,12 @@
            AND a.target_type = 'COMMENT'
     </select>
 
+
+    <select id="selectAttachmentInfoForDownload" parameterType="long" resultMap="AttachmentDownloadMap">
+        SELECT
+               url
+             , origin_name
+          FROM attachment
+         WHERE id = #{attachmentId}
+    </select>
 </mapper>

--- a/src/main/resources/mapper/CommentMapper.xml
+++ b/src/main/resources/mapper/CommentMapper.xml
@@ -72,4 +72,11 @@
         AND a.type = 'NOTICE'
         AND a.is_notice = true
     </select>
+
+    <select id="selectAllComments" parameterType="long">
+        SELECT
+               id
+          FROM comment
+         WHERE work_id = #{taskId}
+    </select>
 </mapper>

--- a/src/main/resources/sql/DDL.sql
+++ b/src/main/resources/sql/DDL.sql
@@ -350,3 +350,4 @@ INSERT INTO delay_reason (reason) VALUES
                                       ('외주 업체 문제'),
                                       ('의사 결정 지연'),
                                       ('기타');
+commit;

--- a/src/main/resources/sql/master.sql
+++ b/src/main/resources/sql/master.sql
@@ -34,3 +34,5 @@ CREATE TABLE user (
 
 INSERT INTO user (id, employee_num, password, name, email)
 VALUES ('0', 'master', '$2a$12$dD0aS4kIMvZnWIWxVXr.3us3W97791wgVLi2gyY4kuCU6/KQMHrcG', 'master', 'test@master.com');
+
+commit;


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.
댓글과 같이 첨부파일을 조회하게 하여 댓글에도 첨부파일을 볼 수 있게 해준다.
Attachment에 TargetId가 댓글 id로 들어가게 해서 댓글별로 조회를 되게끔 하기위해 파사드를 최대한 활용한 로직으로 개선

## 📌 변경 사항 (Changes)
- [ ] 주요 기능 추가 / 변경
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 🌿 작업한 브랜치 (Working Branch)
> 예: `feature/게시글-작성`

- 현재 PR이 어떤 브랜치에서 작업되었는지 명시해주세요.
- refactor/comment

## 📂 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요. (`#이슈번호`)
- close #217 

## 💡 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)

## 📎 기타 참고 사항
- 코드 리뷰 중점적으로 봐줬으면 하는 부분
- 구현 중 고민된 점 등

## 📸 스크린샷 (선택)
UI 관련 변경사항이 있다면 스크린샷을 첨부해주세요.